### PR TITLE
Add json agent ddl export to generic packages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,9 +19,6 @@ Style/SingleLineBlockParams:
 Style/NumericPredicate:
   EnforcedStyle: comparison
 
-Style/TrailingUnderscoreVariable:
-  Enabled: false
-
 Lint/NonLocalExitFromIterator:
   Enabled: false
 
@@ -69,9 +66,6 @@ Layout/SpaceInsideBlockBraces:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
-
-Style/Documentation:
-  Severity: warning
 
 Style/EachWithObject:
   Enabled: false
@@ -158,7 +152,7 @@ Performance/RegexpMatch:
 Style/SafeNavigation:
   Enabled: false
 
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Enabled: false
 
 Performance/StringReplacement:

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "rubygems"
 require "rubygems/package_task"
 
-PROJ_VERSION = "2.20.6"
+PROJ_VERSION = "2.21.0"
 
 spec = Gem::Specification.new do |s|
   s.name = "choria-mcorpc-support"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "rubygems"
 require "rubygems/package_task"
 
-PROJ_VERSION = "2.20.5"
+PROJ_VERSION = "2.20.6"
 
 spec = Gem::Specification.new do |s|
   s.name = "choria-mcorpc-support"

--- a/lib/mcollective/pluginpackager/debpackage_packager.rb
+++ b/lib/mcollective/pluginpackager/debpackage_packager.rb
@@ -35,6 +35,8 @@ module MCollective
           @build_dir = File.join(@tmpdir, "#{@package_name}_#{@plugin.metadata[:version]}")
           Dir.mkdir(@build_dir)
 
+          PluginPackager.generate_agent_json_ddls(@plugin, File.join(@build_dir, @libdir))
+
           create_debian_dir
           @plugin.packagedata.each do |type, data|
             prepare_tmpdirs(data)

--- a/lib/mcollective/pluginpackager/debpackage_packager.rb
+++ b/lib/mcollective/pluginpackager/debpackage_packager.rb
@@ -35,7 +35,6 @@ module MCollective
           @build_dir = File.join(@tmpdir, "#{@package_name}_#{@plugin.metadata[:version]}")
           Dir.mkdir(@build_dir)
 
-          PluginPackager.generate_agent_json_ddls(@plugin, File.join(@build_dir, @libdir))
 
           create_debian_dir
           @plugin.packagedata.each do |type, data|
@@ -43,6 +42,7 @@ module MCollective
             create_install_file(type, data)
             create_pre_and_post_install(type)
           end
+          PluginPackager.generate_agent_json_ddls(@plugin, File.join(@build_dir, @libdir))
           create_debian_files
           create_tar
           run_build

--- a/lib/mcollective/pluginpackager/rpmpackage_packager.rb
+++ b/lib/mcollective/pluginpackager/rpmpackage_packager.rb
@@ -50,7 +50,10 @@ module MCollective
           puts "Building packages for #{@package_name} plugin."
 
           @tmpdir = Dir.mktmpdir('mcollective_packager')
+
           prepare_tmpdirs
+
+          PluginPackager.generate_agent_json_ddls(@plugin, File.join(@tmpdir, @package_name_and_version, @libdir))
 
           make_spec_file
           run_build

--- a/spec/unit/mcollective/packagers/modulepackage_packager_spec.rb
+++ b/spec/unit/mcollective/packagers/modulepackage_packager_spec.rb
@@ -63,6 +63,7 @@ module MCollective
         it 'should run through the complete build process' do
           Dir.expects(:mktmpdir).with('mcollective_packager').returns('rspec_tmp')
           @packager.expects(:make_module)
+          @packager.expects(:generate_agent_json_ddls)
           @packager.expects(:run_build)
           @packager.expects(:move_package)
           @packager.expects(:cleanup_tmpdirs)

--- a/spec/unit/mcollective/pluginpackager_spec.rb
+++ b/spec/unit/mcollective/pluginpackager_spec.rb
@@ -151,5 +151,6 @@ module MCollective
                           {:name => 'rspec_debian', :version => '2.0'}]
       end
     end
+
   end
 end


### PR DESCRIPTION
Right now this only functions when you make AIO packages - move it into
the general packager pipeline